### PR TITLE
edit np.str to np.str_

### DIFF
--- a/marcap_utils.py
+++ b/marcap_utils.py
@@ -17,10 +17,10 @@ def marcap_data(start, end=None, code=None):
   end = start if end==None else pd.to_datetime(end)
   df_list = []
 
-  dtypes={'Code':np.str, 'Name':np.str, 
+  dtypes={'Code':np.str_, 'Name':np.str_, 
           'Open':np.int64, 'High':np.int64, 'Low':np.int64, 'Close':np.int64, 'Volume':np.int64, 'Amount':np.int64,
-          'Changes':np.int64, 'ChangeCode':np.str, 'ChagesRatio':np.float64, 'Marcap':np.int64, 'Stocks':np.int64,
-          'MarketId':np.str, 'Market':np.str, 'Dept':np.str,
+          'Changes':np.int64, 'ChangeCode':np.str_, 'ChagesRatio':np.float64, 'Marcap':np.int64, 'Stocks':np.int64,
+          'MarketId':np.str_, 'Market':np.str_, 'Dept':np.str_,
           'Rank':np.int64}
     
   for year in range(start.year, end.year + 1):


### PR DESCRIPTION
numpy 1.2.0 부터는 np.str이 deprecated

[참조](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)